### PR TITLE
Speed up player movement

### DIFF
--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -2569,7 +2569,7 @@ function startMoving() {
       break;
   }
 
-  movingInterval = setInterval(() => {
+  const doTheMove = () => {
     const newX = player.x + dx;
     const newY = player.y + dy;
 
@@ -2580,12 +2580,10 @@ function startMoving() {
       newY + player.size > canvas.height ||
       isCollision(newX, newY)
     ) {
-      clearInterval(movingInterval); // Stop movement on collision
-      movingInterval = null; // Reset interval reference
       player.x = Math.round(player.x / speed) * speed; // Align position to grid
       player.y = Math.round(player.y / speed) * speed;
       isMoving = false; // Unlock movement
-      
+
       soundEffect.currentTime = 0; // Reset sound playback
       soundEffect.play(); // Play sound effect
 
@@ -2608,8 +2606,12 @@ function startMoving() {
       drawPlayer();
       checkCheckpointCollision(); // Add collision check here
       checkWin();
+
+      requestAnimationFrame(doTheMove);
     }
-  }, 10);
+  };
+
+  requestAnimationFrame(doTheMove);
 }
 
 // Define an array of audio files


### PR DESCRIPTION
If we compare the _Before_ and _After_ videos in the PR we see a marked difference in the speed of player movement in the _After_ video.

> There is still more work to do to with regards to speed but I'm doing them [one logical commit at a time](https://dev.to/samuelfaure/how-atomic-git-commits-dramatically-increased-my-productivity-and-will-increase-yours-too-4a84).

## Before

> I have snipped the video short.

![before](https://github.com/user-attachments/assets/8a9d03ea-d705-49b4-ae68-0839ad30f087)

## After

![after](https://github.com/user-attachments/assets/24ce870a-5a73-4a33-bf20-a6d5b84ff9aa)

This is due to a switch from `setInterval` to `requestAnimationFrame`.

* [requestAnimationFrame](https://developer.mozilla.org/en-US/docs/Web/API/Window/requestAnimationFrame)

When doing tasks such as drawing (animation), using `requestAnimationFrame` is (almost always) the preferred (and better) API:

* [Why?](https://stackoverflow.com/questions/38709923/why-is-requestanimationframe-better-than-setinterval-or-settimeout/38709924#38709924)